### PR TITLE
Updated files to ignore in build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,23 @@
-/.git/ export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
-/.github/ export-ignore
-/composer.json export-ignore
-/composer.lock export-ignore
-/DEVELOPER.md export-ignore
+# Ignore all markdown files
+*.md export-ignore
+
+# Ignore all YAML files
+*.yml export-ignore
+*.yaml export-ignore
+
+# Ignore all XML files
+*.xml export-ignore
+
+# Ignore all config files with specific extensions
+*.neon export-ignore
+*.dist export-ignore
+
+# Ignore entire directories
+docs/ export-ignore
+examples/ export-ignore
+.github/ export-ignore
+
+# Ignore files starting with a dot (hidden files)
+.* export-ignore
+
+# Ignore specific file patterns


### PR DESCRIPTION
The `.gitattributes` file uses more of a regex pattern to ignore the bulk of files we do not want when the package is pulled from GitHub.